### PR TITLE
Update index.html

### DIFF
--- a/examples/cors/frontend/index.html
+++ b/examples/cors/frontend/index.html
@@ -40,7 +40,7 @@
     <p>
         This page requests an asset from another domain via cross-site XMLHttpRequest mitigated by Access Control.<br/>
         This scenario demonstrates a <a href="https://www.w3.org/TR/cors/#simple-method">simple method</a>.<br/>
-        It does <b>NOT</b> dispatch a preflight request.
+        It does <strong>NOT<strong> dispatch a preflight request.
     </p>
     <p>
         Enter the IP address of backend Docker container. As we are running Docker Compose this should just be localhost.<br/>


### PR DESCRIPTION
in order to convey semantics, the <b> and <i> tags shall never be used,
in order to convey styling information, the <b> and <i> should be avoided and CSS should be used instead.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
